### PR TITLE
feat: Create matcher for Dagger errors

### DIFF
--- a/.github/actions/problem-matchers/README.md
+++ b/.github/actions/problem-matchers/README.md
@@ -1,6 +1,8 @@
 # Problem Matchers Action
 
-This action adds problem matchers that scan the job log for errors and warnings from Gradle, Kotlin, and Android Lint. Any detected lines will be highlighted in the job log and an Annotation will be created, making it easier to see the problems when a job goes wrong.
+This action adds Problem Matchers that scan the job log for errors and warnings from Gradle, Kotlin, Dagger, and Android Lint. Any detected lines will be highlighted in the job log and an Annotation will be created, making it easier to see the problems when a job goes wrong. 
+
+For more info about Problem Matchers, see: https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md  
 
 ## Usage
 
@@ -11,7 +13,7 @@ jobs:
   build:
     steps:
       - name: Problem Matchers
-        uses: Shared-CI-Action-Android/problem-matchers
+        uses: krogerco/Shared-CI-Action-Android/.github/actions/problem-matchers@<latest-version>
       - name: Build
         run: ./gradlew build
 ```

--- a/.github/actions/problem-matchers/action.yml
+++ b/.github/actions/problem-matchers/action.yml
@@ -10,3 +10,4 @@ runs:
         echo "::add-matcher::$GITHUB_ACTION_PATH/gradle_matcher.json"
         echo "::add-matcher::$GITHUB_ACTION_PATH/kotlin_matcher.json"
         echo "::add-matcher::$GITHUB_ACTION_PATH/android_lint_matcher.json"
+        echo "::add-matcher::$GITHUB_ACTION_PATH/dagger_matcher.json"

--- a/.github/actions/problem-matchers/dagger_matcher.json
+++ b/.github/actions/problem-matchers/dagger_matcher.json
@@ -1,0 +1,14 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "dagger-errors",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^error:(.*)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actions/problem-matchers/dagger_matcher_test_cases.txt
+++ b/.github/actions/problem-matchers/dagger_matcher_test_cases.txt
@@ -1,0 +1,2 @@
+# This should be detected by dagger-errors
+error: InjectProcessingStep was unable to process 'DependantClass(some.dependency.Class)' because 'some.dependency.Class' could not be resolved.


### PR DESCRIPTION
This adds a problem matcher for a Dagger error that was not caught by the other existing matchers.