### PR TITLE
feat: update to use setup-gradle action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,8 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Gradle Assemble
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: assemble
+      shell: bash
+      run: ./gradlew assemble

--- a/.github/actions/code-coverage/action.yml
+++ b/.github/actions/code-coverage/action.yml
@@ -45,10 +45,12 @@ runs:
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
+
     - name: Run code coverage gradle command
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: ${{ inputs.gradle_command }}
+      shell: bash
+      run: ./gradlew ${{ inputs.gradle_command }}
 
     - name: Add coverage to PR comment
       id: code_coverage_report

--- a/.github/actions/gradle-task/action.yml
+++ b/.github/actions/gradle-task/action.yml
@@ -27,7 +27,8 @@ runs:
     - name: Setup Android SDK
       if: inputs.setup_android_sdk == 'true'
       uses: android-actions/setup-android@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Run Gradle Command
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: ${{ inputs.gradle_command }}
+      shell: bash
+      run: ./gradlew ${{ inputs.gradle_command }}

--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -16,7 +16,8 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Gradle Publish
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: publish
+      shell: bash
+      run: ./gradlew publish

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -19,10 +19,11 @@ runs:
         java-version: ${{ inputs.java_version }}
     - name: Setup Android SDK
       uses: android-actions/setup-android@v3
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Gradle Test
-      uses: gradle/gradle-build-action@v3
-      with:
-        arguments: ${{ inputs.test_command }}
+      shell: bash
+      run: ./gradlew ${{ inputs.test_command }}
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v4
       if: success() || failure()

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Shared actions used by Kroger's GitHub actions.
 
 ## Actions
 - [Build](.github/actions/build)
-    - Uses `gradle/gradle-build-action` and calls `assemble`
+    - Uses `gradle/actions/setup-gradle` and calls `assemble`
     - Inputs:
         - Java Version - 17 is recommended
 - [Code Coverage](.github/actions/code-coverage)
@@ -37,7 +37,7 @@ Shared actions used by Kroger's GitHub actions.
         - Semantic Release Version - 21+ recommended
         - Conventional Changelog Version - 5+ recommended
 - [Gradle Task](.github/actions/gradle-task)
-    - Uses `gradle/gradle-build-action` and calls the Gradle Command input.
+    - Uses `gradle/actions/setup-gradle` and calls the Gradle Command input.
     - Inputs:
         - Gradle Command - The gradle task to execute
         - Java Distribution - The distribution of Java to use
@@ -62,7 +62,7 @@ Shared actions used by Kroger's GitHub actions.
         - Semantic Release Version - 21+ recommended
         - Conventional Changelog Version - 5+ recommended
 - [Unit Tests](.github/actions/unit-tests)
-    - Uses `gradle/gradle-build-action` and calls the Test Command input. Test results are published using `mikepenz/action-junit-report`.
+    - Uses `gradle/actions/setup-gradle` and calls the Test Command input. Test results are published using `mikepenz/action-junit-report`.
     - Inputs:
         - Java Version - 17 is recommended
         - Test Command - The gradle task to run your tests, e.g. `test`


### PR DESCRIPTION
Replaces deprecated `gradle-build-action` with `setup-gradle`.