### PR TITLE
fix: disable body-max-line-length

### DIFF
--- a/.github/actions/commit-lint/action.yml
+++ b/.github/actions/commit-lint/action.yml
@@ -29,7 +29,7 @@ runs:
             "extends": [
               "@commitlint/config-conventional"
             ],
-            rules: {
+            "rules": {
               "body-max-line-length": ["0", "always", 100]
             }
           }

--- a/.github/actions/commit-lint/action.yml
+++ b/.github/actions/commit-lint/action.yml
@@ -28,7 +28,10 @@ runs:
           {
             "extends": [
               "@commitlint/config-conventional"
-            ]
+            ],
+            rules: {
+              "body-max-line-length": ["0", "always", 100]
+            }
           }
         JSON
         )

--- a/.github/actions/commit-lint/action.yml
+++ b/.github/actions/commit-lint/action.yml
@@ -30,7 +30,7 @@ runs:
               "@commitlint/config-conventional"
             ],
             "rules": {
-              "body-max-line-length": ["0", "always", 100]
+              "body-max-line-length": [0, "always", 100]
             }
           }
         JSON

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -31,6 +31,25 @@ jobs:
           node_version: 20
           commitlint_version: 17
 
+      - name: Prepare Long Body Good Commit Test
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "Actions"
+          
+          git checkout --orphan "test-single-good-commit-${{ github.sha }}-${{ github.run_id }}"
+          git rm -rf .
+          git commit --allow-empty -m 'chore: initial commit'
+          git tag 0.0.1
+          git commit --allow-empty -m 'feat: this commit with a long body should pass muster' -m 'Here is a body with a very long line length that exceeds 100 characters, but I say that is okay in my book.'
+
+          git checkout ${{ github.sha }} -- .github/actions/commit-lint/action.yml
+      
+      - name: Long Body Good Commit Test
+        uses: ./.github/actions/commit-lint
+        with:
+          node_version: 20
+          commitlint_version: 17
+
       - name: Prepare Single Bad Commit Test
         run: |
           git config user.email "actions@github.com"

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Prepare Single Good Commit Test
         run: |
           git config user.email "actions@github.com"
@@ -36,7 +36,7 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "Actions"
           
-          git checkout --orphan "test-single-good-commit-${{ github.sha }}-${{ github.run_id }}"
+          git checkout --orphan "test-long-body-good-commit-${{ github.sha }}-${{ github.run_id }}"
           git rm -rf .
           git commit --allow-empty -m 'chore: initial commit'
           git tag 0.0.1

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -31,25 +31,6 @@ jobs:
           node_version: 20
           commitlint_version: 17
 
-      - name: Prepare Long Body Good Commit Test
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "Actions"
-          
-          git checkout --orphan "test-long-body-good-commit-${{ github.sha }}-${{ github.run_id }}"
-          git rm -rf .
-          git commit --allow-empty -m 'chore: initial commit'
-          git tag 0.0.1
-          git commit --allow-empty -m 'feat: this commit with a long body should pass muster' -m 'Here is a body with a very long line length that exceeds 100 characters, but I say that is okay in my book.'
-
-          git checkout ${{ github.sha }} -- .github/actions/commit-lint/action.yml
-      
-      - name: Long Body Good Commit Test
-        uses: ./.github/actions/commit-lint
-        with:
-          node_version: 20
-          commitlint_version: 17
-
       - name: Prepare Single Bad Commit Test
         run: |
           git config user.email "actions@github.com"
@@ -90,6 +71,25 @@ jobs:
         id: multiple-bad-commits
         uses: ./.github/actions/commit-lint
         continue-on-error: true
+        with:
+          node_version: 20
+          commitlint_version: 17
+
+      - name: Prepare Long Body Good Commit Test
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "Actions"
+          
+          git checkout --orphan "test-long-body-good-commit-${{ github.sha }}-${{ github.run_id }}"
+          git rm -rf .
+          git commit --allow-empty -m 'chore: initial commit'
+          git tag 0.0.4
+          git commit --allow-empty -m 'feat: this commit with a long body should pass muster' -m 'Here is a body with a very long line length that exceeds 100 characters, but I say that is okay in my book.'
+
+          git checkout ${{ github.sha }} -- .github/actions/commit-lint/action.yml
+      
+      - name: Long Body Good Commit Test
+        uses: ./.github/actions/commit-lint
         with:
           node_version: 20
           commitlint_version: 17


### PR DESCRIPTION
This rule often breaks commits created by dependabot that have long lines with links to dependencies in them.